### PR TITLE
Add Delete User Data extension

### DIFF
--- a/extensions/delete-user-data.env
+++ b/extensions/delete-user-data.env
@@ -1,0 +1,11 @@
+ALLOWED_EVENT_TYPES=firebase.extensions.delete-user-data.v1.database
+AUTO_DISCOVERY_SEARCH_DEPTH=3
+AUTO_DISCOVERY_SEARCH_FIELDS=id,uid,userId
+CLOUD_STORAGE_BUCKET=tsunami-c067e.appspot.com
+ENABLE_AUTO_DISCOVERY=no
+EVENTARC_CHANNEL=projects/${param:PROJECT_ID}/locations/us-central1/channels/firebase
+FIRESTORE_DELETE_MODE=recursive
+LOCATION=us-central1
+RTDB_PATHS=participants/{UID}
+SELECTED_DATABASE_INSTANCE=tsunami-c067e-default-rtdb
+SELECTED_DATABASE_LOCATION=us-central1

--- a/firebase.json
+++ b/firebase.json
@@ -69,5 +69,8 @@
   },
   "database": {
     "rules": "database.rules.json"
+  },
+  "extensions": {
+    "delete-user-data": "firebase/delete-user-data@0.1.14"
   }
 }


### PR DESCRIPTION
This PR sets up the [Delete User Data extension](https://extensions.dev/extensions/firebase/delete-user-data) which will delete user's data located at `participants/{userID}` when the user deletes their auth account.